### PR TITLE
Implement crash recovery

### DIFF
--- a/pkg/statemachine/checkpoints.go
+++ b/pkg/statemachine/checkpoints.go
@@ -71,7 +71,7 @@ func (ct *checkpointTracker) reinitialize() {
 				ct.networkConfig = cEntry.NetworkState.Config
 			}
 			cp := ct.checkpoint(cEntry.SeqNo)
-			cp.applyCheckpointMsg(nodeID(ct.myConfig.Id), cEntry.CheckpointValue)
+			cp.stable = true
 			ct.activeCheckpoints.PushBack(cp)
 		},
 	})

--- a/pkg/statemachine/epoch_target.go
+++ b/pkg/statemachine/epoch_target.go
@@ -783,6 +783,9 @@ func (et *epochTarget) checkEpochResumed() {
 	case et.commitState.lowWatermark+1 != et.startingSeqNo:
 		et.logger.Log(LevelDebug, "epoch waiting for state transfer to complete (and possibly to initiate)", "epoch_no", et.number)
 		// we are waiting for state transfer to initiate and complete
+		if et.myNewEpoch == nil {
+			et.state = etPending
+		}
 	default:
 		// There is room to allocate sequences, and the commit
 		// state is ready for those sequences to commit, begin


### PR DESCRIPTION
This PR implements crash recovery. A node first waits until the end of the current epoch to receive the state it should transfer to, after which it transfers to this state via the transfer mechanism.